### PR TITLE
Add assertions to document key assumptions in Parser and Event

### DIFF
--- a/src/main/java/jerome/Parser.java
+++ b/src/main/java/jerome/Parser.java
@@ -25,6 +25,7 @@ public class Parser {
      */
     public static Command parse(String input) throws JeromeException {
         String[] separated = input.split(" ", 2);
+        assert input != null : "Input should not be null";
         String command = separated[0];
         String args = separated.length > 1  ? separated[1] : "";
 
@@ -34,6 +35,7 @@ public class Parser {
         case "list":
             return new ListCommand();
         case "find":
+            assert args != null && !args.isEmpty(): "find should not be empty";
             return new FindCommand(args);
         case "mark":
             try {

--- a/src/main/java/jerome/task/Event.java
+++ b/src/main/java/jerome/task/Event.java
@@ -38,6 +38,8 @@ public class Event extends Task {
      */
     public Event(String description, boolean isDone, String start, String end) {
         super(description, isDone);
+        assert start != null && start.split(" ").length > 1 : "start should not be null and should not have length <= 1";
+        assert end != null && end.split(" ").length > 1 : "end should not be null and should not have length <= 1";
         String[] temp;
         temp = start.split(" ");
         this.start = LocalDate.parse(String.join(" ", Arrays.copyOfRange(temp, 1, temp.length)));


### PR DESCRIPTION
Some methods make assumptions about their inputs that are not explicitly documented.

Let's add assertions to the Parser and Event to assert that inputs are non-null, non-empty and valid.

This improves code clarity by making implicit assumptions explicit.